### PR TITLE
Made the form title font slightly smaller and break the words if too long on mobile devices

### DIFF
--- a/src/styled/generic/form.ts
+++ b/src/styled/generic/form.ts
@@ -42,11 +42,15 @@ export const MetaformTitle = styled(Typography, {
   label: "metaform-title"
 })(({ theme }) => ({
   textAlign: "center",
+  wordBreak: "break-word",
   fontSize: 36,
   fontWeight: "bold",
   color: theme.palette.text.primary,
   fontFamily: "Arial, sans-serif",
-  marginBottom: theme.spacing(2)
+  marginBottom: theme.spacing(2),
+  "@media(max-width: 510px)": {
+    fontSize: 28
+  }
 }));
 
 /**


### PR DESCRIPTION
resolves #371 

- Devices under 510px wide Title font-size: 36px -> 28px
- Added word-break: break-word; 